### PR TITLE
Jpa 인터페이스 분리 및 TodoRepositoryImpl 구현체 추가 + 테스트코드

### DIFF
--- a/src/main/java/com/example/todo/infrastructure/persistence/JpaTodoRepository.java
+++ b/src/main/java/com/example/todo/infrastructure/persistence/JpaTodoRepository.java
@@ -1,15 +1,12 @@
 package com.example.todo.infrastructure.persistence;
 
 import com.example.todo.domain.model.Todo;
-import com.example.todo.domain.repository.TodoRepository;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface JpaTodoRepository extends JpaRepository<Todo, Long>,
-    TodoRepository {
+import java.util.List;
 
-  @Override
-  List<Todo> findByCompleted(boolean completed);
+@Repository
+public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
+    List<Todo> findByCompleted(boolean completed);
 } 

--- a/src/main/java/com/example/todo/infrastructure/persistence/TodoRepositoryImpl.java
+++ b/src/main/java/com/example/todo/infrastructure/persistence/TodoRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.example.todo.infrastructure.persistence;
+
+import com.example.todo.domain.model.Todo;
+import com.example.todo.domain.repository.TodoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class TodoRepositoryImpl implements TodoRepository {
+    
+    private final JpaTodoRepository jpaTodoRepository;
+    
+    public TodoRepositoryImpl(JpaTodoRepository jpaTodoRepository) {
+        this.jpaTodoRepository = jpaTodoRepository;
+    }
+    
+    @Override
+    public Todo save(Todo todo) {
+        return jpaTodoRepository.save(todo);
+    }
+    
+    @Override
+    public Optional<Todo> findById(Long id) {
+        return jpaTodoRepository.findById(id);
+    }
+    
+    @Override
+    public List<Todo> findAll() {
+        return jpaTodoRepository.findAll();
+    }
+    
+    @Override
+    public void deleteById(Long id) {
+        jpaTodoRepository.deleteById(id);
+    }
+    
+    @Override
+    public List<Todo> findByCompleted(boolean completed) {
+        return jpaTodoRepository.findByCompleted(completed);
+    }
+} 

--- a/src/test/java/com/example/todo/application/service/TodoServiceTest.java
+++ b/src/test/java/com/example/todo/application/service/TodoServiceTest.java
@@ -1,0 +1,195 @@
+package com.example.todo.application.service;
+
+import com.example.todo.domain.model.Todo;
+import com.example.todo.domain.repository.TodoRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TodoServiceTest {
+
+    @Mock
+    private TodoRepository todoRepository;
+
+    @InjectMocks
+    private TodoService todoService;
+
+    @Test
+    @DisplayName("Todo 생성 시 저장소에 저장되어야 한다")
+    void createTodo() {
+        // given
+        String title = "테스트 할일";
+        String description = "테스트 설명";
+        Todo todo = new Todo(title, description);
+        when(todoRepository.save(any(Todo.class))).thenReturn(todo);
+
+        // when
+        Todo savedTodo = todoService.createTodo(title, description);
+
+        // then
+        assertThat(savedTodo.getTitle()).isEqualTo(title);
+        assertThat(savedTodo.getDescription()).isEqualTo(description);
+        verify(todoRepository).save(any(Todo.class));
+    }
+
+    @Test
+    @DisplayName("ID로 Todo를 조회할 수 있어야 한다")
+    void getTodo() {
+        // given
+        Long id = 1L;
+        Todo todo = new Todo("테스트", "설명");
+        when(todoRepository.findById(id)).thenReturn(Optional.of(todo));
+
+        // when
+        Todo foundTodo = todoService.getTodo(id);
+
+        // then
+        assertThat(foundTodo).isNotNull();
+        assertThat(foundTodo.getTitle()).isEqualTo("테스트");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID로 Todo를 조회하면 예외가 발생해야 한다")
+    void getTodoNotFound() {
+        // given
+        Long id = 1L;
+        when(todoRepository.findById(id)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> {
+            todoService.getTodo(id);
+        });
+    }
+
+    @Test
+    @DisplayName("모든 Todo를 조회할 수 있어야 한다")
+    void getAllTodos() {
+        // given
+        Todo todo1 = new Todo("테스트1", "설명1");
+        Todo todo2 = new Todo("테스트2", "설명2");
+        when(todoRepository.findAll()).thenReturn(Arrays.asList(todo1, todo2));
+
+        // when
+        List<Todo> todos = todoService.getAllTodos();
+
+        // then
+        assertThat(todos).hasSize(2);
+        assertThat(todos).extracting("title").containsExactly("테스트1", "테스트2");
+    }
+
+    @Test
+    @DisplayName("완료된 Todo만 조회할 수 있어야 한다")
+    void getCompletedTodos() {
+        // given
+        Todo todo1 = new Todo("테스트1", "설명1");
+        Todo todo2 = new Todo("테스트2", "설명2");
+        todo1.complete();
+        when(todoRepository.findByCompleted(true)).thenReturn(Arrays.asList(todo1));
+
+        // when
+        List<Todo> completedTodos = todoService.getCompletedTodos();
+
+        // then
+        assertThat(completedTodos).hasSize(1);
+        assertThat(completedTodos.get(0).getTitle()).isEqualTo("테스트1");
+    }
+
+    @Test
+    @DisplayName("미완료된 Todo만 조회할 수 있어야 한다")
+    void getIncompleteTodos() {
+        // given
+        Todo todo1 = new Todo("테스트1", "설명1");
+        Todo todo2 = new Todo("테스트2", "설명2");
+        todo1.complete();
+        when(todoRepository.findByCompleted(false)).thenReturn(Arrays.asList(todo2));
+
+        // when
+        List<Todo> incompleteTodos = todoService.getIncompleteTodos();
+
+        // then
+        assertThat(incompleteTodos).hasSize(1);
+        assertThat(incompleteTodos.get(0).getTitle()).isEqualTo("테스트2");
+    }
+
+    @Test
+    @DisplayName("Todo를 업데이트할 수 있어야 한다")
+    void updateTodo() {
+        // given
+        Long id = 1L;
+        Todo todo = new Todo("테스트", "설명");
+        when(todoRepository.findById(id)).thenReturn(Optional.of(todo));
+        when(todoRepository.save(any(Todo.class))).thenReturn(todo);
+
+        // when
+        Todo updatedTodo = todoService.updateTodo(id, "새로운 제목", "새로운 설명");
+
+        // then
+        assertThat(updatedTodo.getTitle()).isEqualTo("새로운 제목");
+        assertThat(updatedTodo.getDescription()).isEqualTo("새로운 설명");
+        verify(todoRepository).save(any(Todo.class));
+    }
+
+    @Test
+    @DisplayName("Todo를 완료 처리할 수 있어야 한다")
+    void completeTodo() {
+        // given
+        Long id = 1L;
+        Todo todo = new Todo("테스트", "설명");
+        when(todoRepository.findById(id)).thenReturn(Optional.of(todo));
+        when(todoRepository.save(any(Todo.class))).thenReturn(todo);
+
+        // when
+        Todo completedTodo = todoService.completeTodo(id);
+
+        // then
+        assertThat(completedTodo.isCompleted()).isTrue();
+        verify(todoRepository).save(any(Todo.class));
+    }
+
+    @Test
+    @DisplayName("Todo를 미완료 처리할 수 있어야 한다")
+    void uncompleteTodo() {
+        // given
+        Long id = 1L;
+        Todo todo = new Todo("테스트", "설명");
+        todo.complete();
+        when(todoRepository.findById(id)).thenReturn(Optional.of(todo));
+        when(todoRepository.save(any(Todo.class))).thenReturn(todo);
+
+        // when
+        Todo uncompletedTodo = todoService.uncompleteTodo(id);
+
+        // then
+        assertThat(uncompletedTodo.isCompleted()).isFalse();
+        verify(todoRepository).save(any(Todo.class));
+    }
+
+    @Test
+    @DisplayName("Todo를 삭제할 수 있어야 한다")
+    void deleteTodo() {
+        // given
+        Long id = 1L;
+        Todo todo = new Todo("테스트", "설명");
+        when(todoRepository.findById(id)).thenReturn(Optional.of(todo));
+        when(todoRepository.save(any(Todo.class))).thenReturn(todo);
+
+        // when
+        todoService.deleteTodo(id);
+
+        // then
+        verify(todoRepository).save(any(Todo.class));
+    }
+} 

--- a/src/test/java/com/example/todo/domain/model/TodoTest.java
+++ b/src/test/java/com/example/todo/domain/model/TodoTest.java
@@ -1,0 +1,134 @@
+package com.example.todo.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TodoTest {
+
+    @Test
+    @DisplayName("Todo 생성 시 기본값이 올바르게 설정되어야 한다")
+    void createTodo() {
+        // given
+        String title = "테스트 할일";
+        String description = "테스트 설명";
+
+        // when
+        Todo todo = new Todo(title, description);
+
+        // then
+        assertThat(todo.getTitle()).isEqualTo(title);
+        assertThat(todo.getDescription()).isEqualTo(description);
+        assertThat(todo.isCompleted()).isFalse();
+        assertThat(todo.getCreatedAt()).isNotNull();
+        assertThat(todo.getUpdatedAt()).isEqualTo(todo.getCreatedAt());
+        assertThat(todo.getCompletedAt()).isNull();
+        assertThat(todo.getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("Todo 완료 시 상태가 올바르게 변경되어야 한다")
+    void completeTodo() {
+        // given
+        Todo todo = new Todo("테스트", "설명");
+
+        // when
+        todo.complete();
+
+        // then
+        assertThat(todo.isCompleted()).isTrue();
+        assertThat(todo.getCompletedAt()).isNotNull();
+        assertThat(todo.getUpdatedAt()).isEqualTo(todo.getCompletedAt());
+    }
+
+    @Test
+    @DisplayName("이미 완료된 Todo를 다시 완료하려고 하면 상태가 변경되지 않아야 한다")
+    void completeAlreadyCompletedTodo() {
+        // given
+        Todo todo = new Todo("테스트", "설명");
+        todo.complete();
+        var completedAt = todo.getCompletedAt();
+        var updatedAt = todo.getUpdatedAt();
+
+        // when
+        todo.complete();
+
+        // then
+        assertThat(todo.isCompleted()).isTrue();
+        assertThat(todo.getCompletedAt()).isEqualTo(completedAt);
+        assertThat(todo.getUpdatedAt()).isEqualTo(updatedAt);
+    }
+
+    @Test
+    @DisplayName("Todo 미완료 시 상태가 올바르게 변경되어야 한다")
+    void uncompleteTodo() {
+        // given
+        Todo todo = new Todo("테스트", "설명");
+        todo.complete();
+
+        // when
+        todo.uncompleted();
+
+        // then
+        assertThat(todo.isCompleted()).isFalse();
+        assertThat(todo.getCompletedAt()).isNull();
+        assertThat(todo.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("제목 업데이트 시 올바르게 변경되어야 한다")
+    void updateTitle() {
+        // given
+        Todo todo = new Todo("테스트", "설명");
+        String newTitle = "새로운 제목";
+
+        // when
+        todo.updateTitle(newTitle);
+
+        // then
+        assertThat(todo.getTitle()).isEqualTo(newTitle);
+        assertThat(todo.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("빈 제목으로 업데이트 시 예외가 발생해야 한다")
+    void updateTitleWithEmptyTitle() {
+        // given
+        Todo todo = new Todo("테스트", "설명");
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> {
+            todo.updateTitle("");
+        });
+    }
+
+    @Test
+    @DisplayName("설명 업데이트 시 올바르게 변경되어야 한다")
+    void updateDescription() {
+        // given
+        Todo todo = new Todo("테스트", "설명");
+        String newDescription = "새로운 설명";
+
+        // when
+        todo.updateDescription(newDescription);
+
+        // then
+        assertThat(todo.getDescription()).isEqualTo(newDescription);
+        assertThat(todo.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Todo 삭제 시 삭제 시간이 설정되어야 한다")
+    void deleteTodo() {
+        // given
+        Todo todo = new Todo("테스트", "설명");
+
+        // when
+        todo.delete();
+
+        // then
+        assertThat(todo.getDeletedAt()).isNotNull();
+        assertThat(todo.isDeleted()).isTrue();
+    }
+} 

--- a/src/test/java/com/example/todo/infrastructure/persistence/JpaTodoRepositoryTest.java
+++ b/src/test/java/com/example/todo/infrastructure/persistence/JpaTodoRepositoryTest.java
@@ -1,0 +1,103 @@
+package com.example.todo.infrastructure.persistence;
+
+import com.example.todo.domain.model.Todo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class JpaTodoRepositoryTest {
+
+    @Autowired
+    private JpaTodoRepository jpaTodoRepository;
+
+    @Test
+    @DisplayName("Todo를 저장하고 조회할 수 있어야 한다")
+    void saveAndFind() {
+        // given
+        Todo todo = new Todo("테스트", "설명");
+
+        // when
+        Todo savedTodo = jpaTodoRepository.save(todo);
+
+        // then
+        assertThat(savedTodo.getId()).isNotNull();
+        assertThat(savedTodo.getTitle()).isEqualTo("테스트");
+        assertThat(savedTodo.getDescription()).isEqualTo("설명");
+    }
+
+    @Test
+    @DisplayName("완료된 Todo만 조회할 수 있어야 한다")
+    void findByCompleted() {
+        // given
+        Todo todo1 = new Todo("테스트1", "설명1");
+        Todo todo2 = new Todo("테스트2", "설명2");
+        todo1.complete();
+        jpaTodoRepository.save(todo1);
+        jpaTodoRepository.save(todo2);
+
+        // when
+        List<Todo> completedTodos = jpaTodoRepository.findByCompleted(true);
+
+        // then
+        assertThat(completedTodos).hasSize(1);
+        assertThat(completedTodos.get(0).getTitle()).isEqualTo("테스트1");
+    }
+
+    @Test
+    @DisplayName("미완료된 Todo만 조회할 수 있어야 한다")
+    void findByNotCompleted() {
+        // given
+        Todo todo1 = new Todo("테스트1", "설명1");
+        Todo todo2 = new Todo("테스트2", "설명2");
+        todo1.complete();
+        jpaTodoRepository.save(todo1);
+        jpaTodoRepository.save(todo2);
+
+        // when
+        List<Todo> incompleteTodos = jpaTodoRepository.findByCompleted(false);
+
+        // then
+        assertThat(incompleteTodos).hasSize(1);
+        assertThat(incompleteTodos.get(0).getTitle()).isEqualTo("테스트2");
+    }
+
+    @Test
+    @DisplayName("Todo를 업데이트할 수 있어야 한다")
+    void updateTodo() {
+        // given
+        Todo todo = new Todo("테스트", "설명");
+        Todo savedTodo = jpaTodoRepository.save(todo);
+
+        // when
+        savedTodo.updateTitle("새로운 제목");
+        savedTodo.updateDescription("새로운 설명");
+        Todo updatedTodo = jpaTodoRepository.save(savedTodo);
+
+        // then
+        assertThat(updatedTodo.getTitle()).isEqualTo("새로운 제목");
+        assertThat(updatedTodo.getDescription()).isEqualTo("새로운 설명");
+    }
+
+    @Test
+    @DisplayName("Todo를 삭제할 수 있어야 한다")
+    void deleteTodo() {
+        // given
+        Todo todo = new Todo("테스트", "설명");
+        Todo savedTodo = jpaTodoRepository.save(todo);
+
+        // when
+        savedTodo.delete();
+        jpaTodoRepository.save(savedTodo);
+
+        // then
+        assertThat(savedTodo.isDeleted()).isTrue();
+    }
+} 

--- a/src/test/java/com/example/todo/infrastructure/persistence/TodoRepositoryImplTest.java
+++ b/src/test/java/com/example/todo/infrastructure/persistence/TodoRepositoryImplTest.java
@@ -1,0 +1,105 @@
+package com.example.todo.infrastructure.persistence;
+
+import com.example.todo.domain.model.Todo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TodoRepositoryImplTest {
+
+    @Mock
+    private JpaTodoRepository jpaTodoRepository;
+
+    @InjectMocks
+    private TodoRepositoryImpl todoRepository;
+
+    @Test
+    @DisplayName("Todo를 저장할 수 있어야 한다")
+    void save() {
+        // given
+        Todo todo = new Todo("테스트", "설명");
+        when(jpaTodoRepository.save(any(Todo.class))).thenReturn(todo);
+
+        // when
+        Todo savedTodo = todoRepository.save(todo);
+
+        // then
+        assertThat(savedTodo).isNotNull();
+        assertThat(savedTodo.getTitle()).isEqualTo("테스트");
+        verify(jpaTodoRepository).save(todo);
+    }
+
+    @Test
+    @DisplayName("ID로 Todo를 조회할 수 있어야 한다")
+    void findById() {
+        // given
+        Long id = 1L;
+        Todo todo = new Todo("테스트", "설명");
+        when(jpaTodoRepository.findById(id)).thenReturn(Optional.of(todo));
+
+        // when
+        Optional<Todo> foundTodo = todoRepository.findById(id);
+
+        // then
+        assertThat(foundTodo).isPresent();
+        assertThat(foundTodo.get().getTitle()).isEqualTo("테스트");
+    }
+
+    @Test
+    @DisplayName("모든 Todo를 조회할 수 있어야 한다")
+    void findAll() {
+        // given
+        Todo todo1 = new Todo("테스트1", "설명1");
+        Todo todo2 = new Todo("테스트2", "설명2");
+        when(jpaTodoRepository.findAll()).thenReturn(Arrays.asList(todo1, todo2));
+
+        // when
+        List<Todo> todos = todoRepository.findAll();
+
+        // then
+        assertThat(todos).hasSize(2);
+        assertThat(todos).extracting("title").containsExactly("테스트1", "테스트2");
+    }
+
+    @Test
+    @DisplayName("ID로 Todo를 삭제할 수 있어야 한다")
+    void deleteById() {
+        // given
+        Long id = 1L;
+
+        // when
+        todoRepository.deleteById(id);
+
+        // then
+        verify(jpaTodoRepository).deleteById(id);
+    }
+
+    @Test
+    @DisplayName("완료 상태로 Todo를 조회할 수 있어야 한다")
+    void findByCompleted() {
+        // given
+        Todo todo1 = new Todo("테스트1", "설명1");
+        Todo todo2 = new Todo("테스트2", "설명2");
+        todo1.complete();
+        when(jpaTodoRepository.findByCompleted(true)).thenReturn(Arrays.asList(todo1));
+
+        // when
+        List<Todo> completedTodos = todoRepository.findByCompleted(true);
+
+        // then
+        assertThat(completedTodos).hasSize(1);
+        assertThat(completedTodos.get(0).getTitle()).isEqualTo("테스트1");
+    }
+} 


### PR DESCRIPTION
1. 인터페이스 분리:
  JpaTodoRepository는 이제 JpaRepository<Todo, Long>만 상속
  TodoRepository 인터페이스는 별도의 구현체 TodoRepositoryImpl을 통해 구현
2. 구현체 추가:
  TodoRepositoryImpl 클래스를 생성하여 TodoRepository 인터페이스를 구현
  해당 클래스는 JpaTodoRepository를 주입받아 실제 데이터베이스 작업을 수행
3. 테스트 수정:
  JpaTodoRepositoryTest는 이제 JpaTodoRepository를 직접 사용
  TodoRepositoryImplTest를 추가하여 TodoRepository 인터페이스의 구현을 테스트


변경 이유
1. 명확한 책임 분리:
  JpaTodoRepository는 JPA 관련 기능만 담당
  TodoRepositoryImpl은 도메인 리포지토리 인터페이스를 구현
2. 테스트 용이성:
  각 계층별로 독립적인 테스트가 가능
  Mockito를 사용한 단위 테스트와 실제 데이터베이스를 사용한 통합 테스트를 모두 구현
3. 유지보수성:
  인터페이스와 구현체가 분리되어 있어 코드 변경이 용이
  각 클래스의 책임이 명확하게 바꿈