### PR TITLE
User 레포지토리 -> DDD 아키텍처로 분리

### DIFF
--- a/src/main/java/com/example/todo/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/todo/user/domain/repository/UserRepository.java
@@ -30,18 +30,10 @@ public interface UserRepository {
     Optional<User> findByEmail(String email);
     
     /**
-     * 닉네임으로 사용자 조회
-     * @param nickname 사용자 닉네임
-     * @return 조회된 사용자 (없으면 Optional.empty())
-     */
-    Optional<User> findByNickname(String nickname);
-    
-    /**
      * 사용자 삭제
-     * @param user 삭제할 사용자
+     * @param id 삭제할 사용자의 ID
      */
-    void delete(User user);
+    void deleteById(Long id);
 
     boolean existsByEmail(String email);
-    boolean existsByNickname(String nickname);
 } 

--- a/src/main/java/com/example/todo/user/infrastructure/persistence/JpaUserRepository.java
+++ b/src/main/java/com/example/todo/user/infrastructure/persistence/JpaUserRepository.java
@@ -1,7 +1,6 @@
 package com.example.todo.user.infrastructure.persistence;
 
 import com.example.todo.user.domain.model.User;
-import com.example.todo.user.domain.repository.UserRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,11 +10,9 @@ import java.util.Optional;
  * JPA 사용자 저장소 구현체
  */
 @Repository
-public interface JpaUserRepository extends JpaRepository<User, Long>, UserRepository {
+public interface JpaUserRepository extends JpaRepository<User, Long> {
     
-    @Override
     Optional<User> findByEmail(String email);
     
-    @Override
-    Optional<User> findByNickname(String nickname);
+    boolean existsByEmail(String email);
 } 

--- a/src/main/java/com/example/todo/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/example/todo/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.example.todo.user.infrastructure.persistence;
+
+import com.example.todo.user.domain.model.User;
+import com.example.todo.user.domain.repository.UserRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class UserRepositoryImpl implements UserRepository {
+    
+    private final JpaUserRepository jpaUserRepository;
+    
+    public UserRepositoryImpl(JpaUserRepository jpaUserRepository) {
+        this.jpaUserRepository = jpaUserRepository;
+    }
+    
+    @Override
+    public User save(User user) {
+        return jpaUserRepository.save(user);
+    }
+    
+    @Override
+    public Optional<User> findById(Long id) {
+        return jpaUserRepository.findById(id);
+    }
+    
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return jpaUserRepository.findByEmail(email);
+    }
+    
+    @Override
+    public void deleteById(Long id) {
+        jpaUserRepository.deleteById(id);
+    }
+    
+    @Override
+    public boolean existsByEmail(String email) {
+        return jpaUserRepository.existsByEmail(email);
+    }
+} 


### PR DESCRIPTION
### 변경 전

user/
├── domain/
│   └── repository/
│       └── UserRepository.java (인터페이스만 존재)
└── infrastructure/
    └── persistence/
        └── JpaUserRepository.java (JPA 인터페이스)

### 변경 후

user/
├── domain/
│   ├── model/
│   │   └── User.java
│   └── repository/
│       └── UserRepository.java (인터페이스)
└── infrastructure/
    └── persistence/
        ├── JpaUserRepository.java (JPA 인터페이스)
        └── UserRepositoryImpl.java (구현체)

### 요약

[ 인터페이스 ] UserRepository     ←   도메인에 가까운 추상화 계층
                           ↑
[ 구현 클래스 ] UserRepositoryImpl   ←   JPA 기술과의 연결, 구현체
                           ↑
[ Spring Data JPA ] JpaUserRepository ←   진짜 DB 동작 담당

---- 

✅ 이렇게 변경하면 얻는 이점
1. JPA 기술과 도메인 레이어를 분리

    JPA가 아닌 다른 저장소(MongoDB, Redis 등)로 바꾸더라도 UserRepository는 그대로 유지 가능.

    테스트에서 Mock을 만들기도 쉬움 (e.g. InMemoryUserRepository).

2. 도메인 주도 설계(Domain-Driven Design) 철학에 맞는 구조

    인프라와 도메인을 느슨하게 결합해서 유지보수성이 높아짐.

3. 유연한 커스터마이징

    UserRepositoryImpl에서 일부만 캐싱하거나, 로직을 추가할 수도 있음.

```java
@Override
public Optional<User> findByEmail(String email) {
    log.info("이메일로 사용자 조회 요청: {}", email);
    return jpaUserRepository.findByEmail(email);
}

```

## ✅ 구조 비교

|항목|변경 전|변경 후|
|---|---|---|
|구조|JPA 인터페이스가 도메인 인터페이스 직접 구현|도메인 인터페이스, JPA 인터페이스, 구현 클래스로 분리|
|의존성|도메인 ↔ JPA 직접 연결|도메인 ↔ 구현체 ↔ JPA (간접 연결)|
|유연성|낮음|높음|
|테스트|어려움 (JPA mock 필요)|쉬움 (Impl만 Mock 처리 가능)|
|책임 분리|애매|명확|

## 현재 구조

        [Application Layer]
               ↓
         UserService (도메인 서비스)

        [Domain Layer]
               ↓
     UserRepository (Port/도메인 추상화)

        [Infrastructure Layer]
               ↓
     UserRepositoryImpl (Adapter)
               ↓
     JpaUserRepository (JPA 어댑터)


